### PR TITLE
fixed message on reconnect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+config.js

--- a/Bot.js
+++ b/Bot.js
@@ -80,26 +80,36 @@ const BoopImg = [
     "https://cdn.discordapp.com/attachments/270372438825500672/283016858402160640/515.gif",
     "https://cdn.discordapp.com/attachments/270372438825500672/283016859014397952/a02.gif"
 ]
-
+var reconnected = false
 /*
   A ping pong bot, whenever you send "ping", it replies "pong".
 */
 // the ready event is vital, it means that your bot will only start reacting to information
 // from Discord _after_ ready is emitted.
 bot.on('ready', () => {
-  console.log("Online~")
-  var timer = setInterval(()=>{bot.user.setGame(playingmsg[Math.floor(Math.random()*playingmsg.length)])},1000*60*60)
-  var guld = bot.guilds.first().defaultChannel
-  guld.sendMessage("I am now online~")
-  rl.on("line", input =>{
-    guld.sendMessage(input)
-})
+    console.log("Online~")
+    var timer = setInterval(() => { bot.user.setGame(playingmsg[Math.floor(Math.random() * playingmsg.length)]) }, 1000 * 60 * 60)
+
+    var guld = bot.guilds.first().defaultChannel
+    if (reconnected) {
+        guld.sendMessage("Reconnected after connection loss.")
+        reconnected = false
+    } else {
+        guld.sendMessage("I am now online~")
+    }
+    rl.on("line", input => {
+        guld.sendMessage(input)
+    })
 })
 
-bot.on("reconnecting", rcnct =>{
-rcnct.defaultChannel.sendMessage("Lost connection, reconnecting..")
-})
 
+bot.on("reconnecting", rcnct => {
+    reconnected = true
+    console.log("reconnecting")
+})
+bot.on("disconnect", () => {
+    console.log("Lost connection!")
+})
 
 
 

--- a/Bot.js
+++ b/Bot.js
@@ -1,3 +1,4 @@
+//Discord bot
 const Discord = require('discord.js')
 const config = require('./config.js')
 const bot = new Discord.Client()

--- a/config.example.js
+++ b/config.example.js
@@ -1,0 +1,7 @@
+//rename this file to config.js and edit the example values below
+module.exports = {
+    ownerID :  '123456789123456789',//add your owner id here
+    botToken : 'bot token here',//add your application token here
+    botID :    '123456789123456789',//add the id of your bot here
+    adminID :  '123456789123456789' //add the admin group id here
+}

--- a/config.js
+++ b/config.js
@@ -1,6 +1,0 @@
-module.exports = {
-    ownerID : '104674953382612992',
-    botToken : 'MjgxNTg5MDMwNTQwMjc5ODA4.C4aJ1g.zfftCpKUEJfmkcT7lxETbQC-rP4',
-    botID : '281589030540279808',
-    adminID : "249405763049619456"
-}


### PR DESCRIPTION
when the bot lost connection it attempted to send a chat message before the ready event was emitted

this fixes that. also added a console log for the disconnect event

added a gitignore and removed config.js

since the config existed before and is still accessible, consider renewing the token for the bot

added example config

warning.. backup the config you have now. by pulling this the first time before the gitignore is in the local directory the config will be deleted. in future updates from this point it wont